### PR TITLE
Fix GitHub import and improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,12 +214,14 @@ docs-mcp-import-url https://example.com/docs --output-dir docs/imported
 
 #### docs-mcp-import-github
 
-GitHub リポジトリからインポートします。ブランチを指定しなくてもデフォルトブランチを自動検出します。
-`DOCS_FOLDERS` が設定されている場合、出力先を指定しなければ最初のフォルダに保存されます。
+GitHubリポジトリからインポート
 
 ```bash
-docs-mcp-import-github https://github.com/owner/repo
+docs-mcp-import-github https://github.com/owner/repo/tree/main/docs --output-dir docs/imported
 ```
+
+オプション:
+- `--output-dir`, `-o`: 出力ディレクトリ（デフォルト: リポジトリ名）
 
 #### docs-mcp-generate-metadata
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ mkdir docs
 # 3. ドキュメントをインポート（オプション）
 uv run docs-mcp-import-url https://docs.example.com
 # または
-uv run docs-mcp-import-github https://github.com/owner/repo/tree/main/docs
+uv run docs-mcp-import-github https://github.com/owner/repo
 
 # 4. メタデータを生成（セマンティック検索用）
 export OPENAI_API_KEY="your-key"
@@ -214,10 +214,11 @@ docs-mcp-import-url https://example.com/docs --output-dir docs/imported
 
 #### docs-mcp-import-github
 
-GitHubリポジトリからインポート
+GitHub リポジトリからインポートします。ブランチを指定しなくてもデフォルトブランチを自動検出します。
+`DOCS_FOLDERS` が設定されている場合、出力先を指定しなければ最初のフォルダに保存されます。
 
 ```bash
-docs-mcp-import-github https://github.com/owner/repo/tree/main/docs
+docs-mcp-import-github https://github.com/owner/repo
 ```
 
 #### docs-mcp-generate-metadata

--- a/src/mcp_server_docs/scripts/github_import.py
+++ b/src/mcp_server_docs/scripts/github_import.py
@@ -5,12 +5,12 @@ Gitのsparse-checkoutを使用してGitHubリポジトリの特定フォルダ�
 
 import argparse
 import os
+import re
 import shutil
 import subprocess
 import tempfile
 from pathlib import Path
 from urllib.parse import urlparse
-import re
 
 
 def parse_github_url(url: str) -> tuple[str, str, str | None, str]:
@@ -80,11 +80,9 @@ def import_with_sparse_checkout(url: str, output_dir: str | None = None):
     # デフォルトの出力先を決定
     if output_dir is None:
         docs_folders = os.getenv("DOCS_FOLDERS")
-        if docs_folders:
-            # DOCS_FOLDERSが設定されている場合は最初のフォルダを使用
-            output_dir = docs_folders.split(",")[0].strip()
-        else:
-            output_dir = repo
+        output_dir = (
+            docs_folders.split(",")[0].strip() if docs_folders else repo
+        )
 
     print("Importing from GitHub repository using Git")
     print(f"Owner: {owner}")

--- a/src/mcp_server_docs/scripts/github_import.py
+++ b/src/mcp_server_docs/scripts/github_import.py
@@ -77,12 +77,9 @@ def import_with_sparse_checkout(url: str, output_dir: str | None = None):
     if branch is None:
         branch = detect_default_branch(clone_url)
 
-    # デフォルトの出力先を決定
+    # デフォルトの出力先をリポジトリ名に設定
     if output_dir is None:
-        docs_folders = os.getenv("DOCS_FOLDERS")
-        output_dir = (
-            docs_folders.split(",")[0].strip() if docs_folders else repo
-        )
+        output_dir = repo
 
     print("Importing from GitHub repository using Git")
     print(f"Owner: {owner}")


### PR DESCRIPTION
## Summary
- Fixed GitHub import to auto-detect default branch (main/master)
- Removed unnecessary DOCS_FOLDERS logic from output directory selection
- Restructured README for better clarity
- Changed all instances of 'my-project' to 'my-docs' for clarity

## Changes
1. **GitHub import improvements**:
   - Added `detect_default_branch()` function to handle repositories with master as default
   - Fixed the issue reported in #[issue-number] where repos with master branch failed to import

2. **Documentation improvements**:
   - Reorganized README with clearer structure
   - Added quick start section at the top
   - Made it clear that docs-mcp manages a dedicated documentation project
   - Separated setup methods more clearly

## Test Results
- ✅ All tests passing
- ✅ Linting and formatting checks pass
- ✅ Type checking passes
- ✅ Tested with UniTask repo (master branch) - works correctly